### PR TITLE
Required option arguments before double dash

### DIFF
--- a/src/test/java/joptsimple/LongOptionRequiredArgumentTest.java
+++ b/src/test/java/joptsimple/LongOptionRequiredArgumentTest.java
@@ -25,12 +25,12 @@
 
 package joptsimple;
 
-import static java.util.Collections.*;
-import static org.infinitest.toolkit.CollectionMatchers.*;
-import static org.junit.Assert.*;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import static java.util.Collections.*;
+import static org.infinitest.toolkit.CollectionMatchers.hasSameContentsAs;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:pholser@alumni.rice.edu">Paul Holser</a>
@@ -85,5 +85,15 @@ public class LongOptionRequiredArgumentTest extends AbstractOptionParserFixture 
         assertOptionDetected( options, "y" );
         assertEquals( singletonList( "bar" ), options.valuesOf( "y" ) );
         assertEquals( emptyList(), options.nonOptionArguments() );
+    }
+
+    @Test
+    public void argumentMissingBeforeDoubleDash() {
+        try {
+            parser.parse("--quiet", "--", "some", "more", "arguments");
+            fail();
+        } catch (OptionMissingRequiredArgumentException expected) {
+            assertThat(expected.options(), hasSameContentsAs(singleton("quiet")));
+        }
     }
 }


### PR DESCRIPTION
Given a parser with a configuration like in the example:
parser.accepts("--foo").withRequiredArgs();

When I parse arguments with the foo option without arguments and a double dash afterwards:
parser.parse("--foo", "--", "non" "option", "args");

Then the parser treats "--" as its argument. I'm not sure if this is the correct behavior, but for me it was quite unexpected.

Anyway… if it's not a bug sorry for taking your time, otherwise there is a short failing test attached.
