### PR TITLE
joda-time dependency needs upgrade version from 2.0 to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.0</version>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Tests using DateMidnight.toDate() method do not compile with joda-time version 2.0
