### PR TITLE
Friendly Exceptions

### DIFF
--- a/src/main/java/joptsimple/OptionArgumentConversionException.java
+++ b/src/main/java/joptsimple/OptionArgumentConversionException.java
@@ -49,6 +49,6 @@ class OptionArgumentConversionException extends OptionException {
 
     @Override
     public String getMessage() {
-        return "Cannot convert argument '" + argument + "' of option " + multipleOptionMessage() + " to " + valueType;
+        return "Cannot parse argument '" + argument + "' of option " + multipleOptionMessage() + ".";
     }
 }

--- a/src/main/java/joptsimple/internal/ReflectionException.java
+++ b/src/main/java/joptsimple/internal/ReflectionException.java
@@ -34,6 +34,6 @@ public class ReflectionException extends RuntimeException {
     private static final long serialVersionUID = -2L;
 
     ReflectionException( Throwable cause ) {
-        super( cause.toString() );
+        super( cause );
     }
 }


### PR DESCRIPTION
Reflection exception now wraps the given throwable rather than the throwable's toString so that the underlying exception can be found. OptionArgumentConversionException's message does not include the class name, allowing it to be printed to an end-user.
