### PR TITLE
Sample for Map<String, String> to OptionSet.

### DIFF
--- a/src/main/java/joptsimple/OptionSet.java
+++ b/src/main/java/joptsimple/OptionSet.java
@@ -71,7 +71,7 @@ public class OptionSet {
     }
 
     /**
-     * Create an new map of keys to option values.
+     * Create an new, unmodifiable map of keys to option values.
      *
      * @param selector the function for finding keys for option specs, never missing
      * @return the map, never missing
@@ -82,8 +82,20 @@ public class OptionSet {
         // Alternate implementation might present a view rather than a copy
         Map<String, Object> map = new LinkedHashMap<String, Object>();
         for ( OptionSpec<?> spec : detectedSpecs )
-            map.put( selector.select(spec), hasArgument(spec) ? valueOf(spec) : true );
-        return map;
+            map.put(selector.select( spec ), valueFor( spec ));
+        return unmodifiableMap( map );
+    }
+
+    private Object valueFor( OptionSpec<?> spec ) {
+        List<?> values = spec.values( this );
+        switch( values.size() ) {
+            case 0:
+                return true;
+            case 1:
+                return values.get( 0 );
+            default:
+                return values;
+        }
     }
 
     /**


### PR DESCRIPTION
Please ignore the import changes.

This is one way to provide a Map interface to parsed options.  I wanted some flexibility in how map key are chosen.  For example in my use case I want to map options onto properties to aid applications in having command line overrides for configuration.

One variant is to prefix the keys so you can have more complex properties than just "debug", e.g., the "--debug" flag becomes the "my.app.debug" key which aligns with a properties file entry somewhere.
