### PR TITLE
Removing Java 7 getLoopbackAddress() call

### DIFF
--- a/src/test/java/joptsimple/util/InetAddressConverterTest.java
+++ b/src/test/java/joptsimple/util/InetAddressConverterTest.java
@@ -79,9 +79,9 @@ public class InetAddressConverterTest {
         @Mock( invocations = 1 )
         public InetAddress getByName( String host ) throws UnknownHostException {
             if ( "localhost".equals( host ) )
-                return InetAddress.getLoopbackAddress();
-            else
-                throw new UnknownHostException( host );
+                return InetAddress.getByAddress( new byte[] { 127, 0, 0, 1 } );
+
+            throw new UnknownHostException( host );
         }
     }
 }


### PR DESCRIPTION
Would like to keep compatible back to Java 5 until we explicitly and loudly say we're leaving it behind.
