### PR TITLE
Make long opt ending with equals have empty value

### DIFF
--- a/src/main/java/joptsimple/ArgumentAcceptingOptionSpec.java
+++ b/src/main/java/joptsimple/ArgumentAcceptingOptionSpec.java
@@ -253,7 +253,7 @@ public abstract class ArgumentAcceptingOptionSpec<V> extends AbstractOptionSpec<
     final void handleOption( OptionParser parser, ArgumentList arguments, OptionSet detectedOptions,
         String detectedArgument ) {
 
-        if ( isNullOrEmpty( detectedArgument ) )
+        if ( detectedArgument == null )
             detectOptionArgument( parser, arguments, detectedOptions );
         else
             addArguments( detectedOptions, detectedArgument );

--- a/src/main/java/joptsimple/util/KeyValuePair.java
+++ b/src/main/java/joptsimple/util/KeyValuePair.java
@@ -54,7 +54,7 @@ public final class KeyValuePair {
     public static KeyValuePair valueOf( String asString ) {
         int equalsIndex = asString.indexOf( '=' );
         if ( equalsIndex == -1 )
-            return new KeyValuePair( asString, EMPTY );
+            return new KeyValuePair( asString, null );
 
         String aKey = asString.substring( 0, equalsIndex );
         String aValue = equalsIndex == asString.length() - 1 ? EMPTY : asString.substring( equalsIndex + 1 );

--- a/src/test/java/joptsimple/examples/LongOptionsWithArgumentsTest.java
+++ b/src/test/java/joptsimple/examples/LongOptionsWithArgumentsTest.java
@@ -31,4 +31,32 @@ public class LongOptionsWithArgumentsTest {
         assertNull( options.valueOf( "level" ) );
         assertEquals( emptyList(), options.valuesOf( "level" ) );
     }
+
+    @Test
+    public void supportsLongOptionsWithEmptyArguments() {
+        OptionParser parser = new OptionParser();
+        parser.accepts( "verbose" );
+        parser.accepts( "brief" );
+        parser.accepts( "add" );
+        parser.accepts( "append" );
+        parser.accepts( "delete" ).withRequiredArg();
+        parser.accepts( "create" ).withRequiredArg();
+        parser.accepts( "file" ).withRequiredArg();
+
+        OptionSet options = parser.parse( "--delete", "", "--add" );
+
+        assertTrue( options.has( "delete" ) );
+        assertTrue( options.hasArgument( "delete" ) );
+        assertEquals( "", options.valueOf( "delete" ) );
+
+        assertTrue( options.has( "add" ) );
+
+        options = parser.parse( "--delete=", "--add" );
+
+        assertTrue( options.has( "delete" ) );
+        assertTrue( options.hasArgument( "delete" ) );
+        assertEquals( "", options.valueOf( "delete" ) );
+
+        assertTrue( options.has( "add" ) );
+    }
 }

--- a/src/test/java/joptsimple/util/KeyValuePairTest.java
+++ b/src/test/java/joptsimple/util/KeyValuePairTest.java
@@ -43,7 +43,7 @@ public class KeyValuePairTest {
         KeyValuePair pair = KeyValuePair.valueOf( "" );
 
         assertEquals( "", pair.key );
-        assertEquals( "", pair.value );
+        assertNull( pair.value );
     }
 
     @Test
@@ -51,7 +51,7 @@ public class KeyValuePairTest {
         KeyValuePair pair = KeyValuePair.valueOf( "aString" );
 
         assertEquals( "aString", pair.key );
-        assertEquals( "", pair.value );
+        assertNull( pair.value );
     }
 
     @Test


### PR DESCRIPTION
Accepting a `delete` option that requires an argument and an `add` option that does not, JOpt Simple parses the arguments `["--delete=", "--add"]` as the option `delete` with the value `--add`, and no `add` option detected.  This is incorrect.  It should parse it as the option `delete` with an empty value, and the option `add` detected.  This changeset makes JOpt Simple treat an option that ends with an equals sign as an option with an empty value.

As of May 5, 2017, on macOS Sierra 10.12.4, the [glibc getopt-long example](https://www.gnu.org/software/libc/manual/html_node/Getopt-Long-Option-Example.html) behaves in the expected way (`d` and `a` are the short forms of `delete` and `add`, respectively):

```
% ./main --delete= --add
option -d with value `'
option -a
```

This fixes issue #116.