### PR TITLE
Add the ability to disable short argument clustering.

### DIFF
--- a/src/main/java/joptsimple/OptionParser.java
+++ b/src/main/java/joptsimple/OptionParser.java
@@ -200,6 +200,7 @@ public class OptionParser implements OptionDeclarer {
     private OptionParserState state;
     private boolean posixlyCorrect;
     private boolean allowsUnrecognizedOptions;
+    private boolean allowsOptionClustering = true;
     private HelpFormatter helpFormatter = new BuiltinHelpFormatter();
 
     /**
@@ -299,6 +300,14 @@ public class OptionParser implements OptionDeclarer {
 
     boolean posixlyCorrect() {
         return posixlyCorrect;
+    }
+
+    public void allowsOptionClustering(boolean allowClustering) {
+        allowsOptionClustering = allowClustering;
+    }
+
+    boolean doesAllowsOptionClustering() {
+        return allowsOptionClustering;
     }
 
     @Override
@@ -528,8 +537,9 @@ public class OptionParser implements OptionDeclarer {
         if ( isRecognized( optionAndArgument.key ) ) {
             specFor( optionAndArgument.key ).handleOption( this, arguments, detected, optionAndArgument.value );
         }
-        else
-            handleShortOptionCluster( candidate, arguments, detected );
+        else if (allowsOptionClustering) {
+            handleShortOptionCluster(candidate, arguments, detected);
+        }
     }
 
     private void handleShortOptionCluster( String candidate, ArgumentList arguments, OptionSet detected ) {

--- a/src/test/java/joptsimple/examples/ShortOptionsClusteringTest.java
+++ b/src/test/java/joptsimple/examples/ShortOptionsClusteringTest.java
@@ -18,4 +18,20 @@ public class ShortOptionsClusteringTest {
         assertTrue( options.has( "c" ) );
         assertTrue( options.has( "d" ) );
     }
+
+    @Test
+    public void rejectsClusteringShortOptions() {
+        OptionParser parser = new OptionParser();
+        parser.allowsOptionClustering(false);
+        parser.accepts( "a" );
+        parser.accepts( "b" );
+        parser.accepts( "c" );
+
+        OptionSet options = parser.parse( "-abcd" );
+        assertFalse(options.has("a"));
+        assertFalse(options.has("b"));
+        assertFalse(options.has("c"));
+        assertFalse(options.has("abcd"));
+    }
+
 }


### PR DESCRIPTION
Proposed fix for https://github.com/jopt-simple/jopt-simple/issues/136. This is my first jopt-simple patch so please let me know if there I missed any conventions, etc. Also, I wasn't sure if the OptionParser methods should be pushed up to OptionDeclarer or not.