### PR TITLE
Add `OptionSet.specsWithNonOptions()` for #125

### DIFF
--- a/src/main/java/joptsimple/OptionParser.java
+++ b/src/main/java/joptsimple/OptionParser.java
@@ -388,7 +388,7 @@ public class OptionParser implements OptionDeclarer {
         return options;
     }
 
-   /**
+    /**
      * Parses the given command line arguments according to the option specifications given to the parser.
      *
      * @param arguments arguments to parse

--- a/src/main/java/joptsimple/OptionSet.java
+++ b/src/main/java/joptsimple/OptionSet.java
@@ -261,14 +261,29 @@ public class OptionSet {
     }
 
     /**
-     * Gives the set of options that were detected, in the form of {@linkplain OptionSpec}s, in the order in which the
-     * options were found on the command line.
+     * Gives the set of options that were detected, in the form of
+     * {@linkplain OptionSpec}s, in the order in which the options were found
+     * on the command line.
      *
      * @return the set of detected command line options
      */
     public List<OptionSpec<?>> specs() {
-        List<OptionSpec<?>> specs = detectedSpecs;
+        List<OptionSpec<?>> specs = new ArrayList<>( detectedSpecs );
         specs.removeAll( singletonList( detectedOptions.get( NonOptionArgumentSpec.NAME ) ) );
+
+        return unmodifiableList( specs );
+    }
+
+    /**
+     * Gives the set of options and non-option arguments that were detected,
+     * in the form of {@linkplain OptionSpec}s, in the order in which they
+     * were found on the command line.
+     *
+     * @return the set of detected command line options and non-option args
+     */
+    public List<OptionSpec<?>> specsWithNonOptions() {
+        List<OptionSpec<?>> specs = new ArrayList<>( detectedSpecs );
+        specs.remove( detectedOptions.get( NonOptionArgumentSpec.NAME ) );
 
         return unmodifiableList( specs );
     }

--- a/src/test/java/joptsimple/NonOptionArgumentSpecTest.java
+++ b/src/test/java/joptsimple/NonOptionArgumentSpecTest.java
@@ -25,11 +25,11 @@
 
 package joptsimple;
 
-import org.junit.Test;
-
 import java.io.File;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.Date;
+
+import org.junit.Test;
 
 import static java.util.Arrays.*;
 import static java.util.Collections.*;
@@ -104,5 +104,20 @@ public class NonOptionArgumentSpecTest extends AbstractOptionParserFixture {
         OptionSet options = parser.parse( "one", "two" );
 
         assertEquals( emptyList(), options.specs() );
+    }
+
+    @Test
+    public void specsCorrespondingToNonOptions() {
+        OptionParser parser = new OptionParser();
+        parser.nonOptions();
+
+        OptionSet options = parser.parse( "one", "two" );
+
+        assertEquals(
+            asList(
+                new NonOptionArgumentSpec( NonOptionArgumentSpec.NAME ),
+                new NonOptionArgumentSpec( NonOptionArgumentSpec.NAME )
+            ),
+            options.specsWithNonOptions() );
     }
 }

--- a/src/test/java/joptsimple/OptionSetSpecsWithNonOptionsTest.java
+++ b/src/test/java/joptsimple/OptionSetSpecsWithNonOptionsTest.java
@@ -1,0 +1,61 @@
+/*
+ The MIT License
+
+ Copyright (c) 2004-2016 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package joptsimple;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import static java.util.Arrays.*;
+import static org.junit.Assert.*;
+
+/**
+ * @author <a href="mailto:pholser@alumni.rice.edu">Paul Holser</a>
+ */
+public class OptionSetSpecsWithNonOptionsTest extends AbstractOptionParserFixture {
+    @Test
+    public void intermixOptionsAndNonOptions() {
+        parser.accepts( "a" );
+        parser.accepts( "b" ).withRequiredArg();
+        parser.accepts( "c" ).withOptionalArg();
+
+        OptionSet options =
+            parser.parse("-a", "foo", "bar", "-b", "baz", "xx", "-c", "quux", "d" );
+
+        List<OptionSpec<?>> specs = options.specsWithNonOptions();
+        assertEquals(
+            asList(
+                new NoArgumentOptionSpec( "a" ),
+                new NonOptionArgumentSpec( NonOptionArgumentSpec.NAME ),
+                new NonOptionArgumentSpec( NonOptionArgumentSpec.NAME ),
+                new RequiredArgumentOptionSpec<String>( "b" ),
+                new NonOptionArgumentSpec( NonOptionArgumentSpec.NAME ),
+                new OptionalArgumentOptionSpec<String>( "c" ),
+                new NonOptionArgumentSpec( NonOptionArgumentSpec.NAME )
+            ),
+            options.specsWithNonOptions() );
+    }
+}


### PR DESCRIPTION
Also having `specs()` and `specsWithNonOptions()` operate on copies
of the detected specs state.