### PR TITLE
Fix ConcurrentModificationException when building on JDK 16

### DIFF
--- a/net.sf.joptsimple/pom.xml
+++ b/net.sf.joptsimple/pom.xml
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.2.1</version>
+                <version>5.1.2</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
With the addition of the maven-bundle-plugin in #150 , the build fails on JDK 16, due to a ConcurrentModificationException in BND. It's the same issue as https://github.com/bndtools/bnd/issues/3903

```
java.util.ConcurrentModificationException
    at java.util.TreeMap.callMappingFunctionWithCheck (TreeMap.java:742)
    at java.util.TreeMap.computeIfAbsent (TreeMap.java:558)
    at aQute.bnd.osgi.Jar.putResource (Jar.java:288)
...
```

Upgrading the maven-bundle-plugin to 5.1.2 solves the issue. Because this is a new major version, I made sure that the manifest contains the same OSGI instructions:

* [JDK 11 / bnd 4.2.0](https://pastebin.com/2Y50g8fe)
* [JDK 16 / bnd 5.1.2](https://pastebin.com/acLTrwFi)
