### PR TITLE
Remove redundant String.valueOf calls

### DIFF
--- a/net.sf.joptsimple/src/main/java/joptsimple/OptionParser.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/OptionParser.java
@@ -316,7 +316,7 @@ public class OptionParser implements OptionDeclarer {
         if ( recognize )
             recognize( new AlternativeLongOptionSpec() );
         else
-            recognizedOptions.remove( String.valueOf( RESERVED_FOR_EXTENSIONS ) );
+            recognizedOptions.remove( RESERVED_FOR_EXTENSIONS );
     }
 
     void recognize( AbstractOptionSpec<?> spec ) {

--- a/net.sf.joptsimple/src/main/java/joptsimple/ParserRules.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/ParserRules.java
@@ -61,7 +61,7 @@ final class ParserRules {
 
     static void ensureLegalOption( String option ) {
         if ( option.startsWith( HYPHEN ) )
-            throw new IllegalOptionSpecificationException( String.valueOf( option ) );
+            throw new IllegalOptionSpecificationException( option );
 
         for ( int i = 0; i < option.length(); ++i )
             ensureLegalOptionCharacter( option.charAt( i ) );


### PR DESCRIPTION
Found them while browsing OpenJDK sources.