### PR TITLE
ValueConverter.revert() should take V instead of Object

### DIFF
--- a/net.sf.joptsimple.tests/src/test/java/tests/joptsimple/ParsingSeparatedConvertedOptionValuesTest.java
+++ b/net.sf.joptsimple.tests/src/test/java/tests/joptsimple/ParsingSeparatedConvertedOptionValuesTest.java
@@ -68,8 +68,8 @@ public class ParsingSeparatedConvertedOptionValuesTest extends AbstractOptionPar
                 }
 
                 @Override
-                public String revert( Object value ) {
-                    return valueType().cast( value ).getPath();
+                public String revert( File value ) {
+                    return value.getPath();
                 }
 
                 @Override

--- a/net.sf.joptsimple.tests/src/test/java/tests/joptsimple/SwitchConverter.java
+++ b/net.sf.joptsimple.tests/src/test/java/tests/joptsimple/SwitchConverter.java
@@ -43,9 +43,8 @@ class SwitchConverter implements ValueConverter<Boolean> {
     }
 
     @Override
-    public String revert( Object value ) {
-        boolean converted = valueType().cast( value );
-        return converted ? "on" : "off";
+    public String revert( Boolean value ) {
+        return value ? "on" : "off";
     }
 
     @Override

--- a/net.sf.joptsimple.tests/src/test/java/tests/joptsimple/ValueConverterAdmitsSubclassesOfValueTypeTest.java
+++ b/net.sf.joptsimple.tests/src/test/java/tests/joptsimple/ValueConverterAdmitsSubclassesOfValueTypeTest.java
@@ -48,8 +48,8 @@ public class ValueConverterAdmitsSubclassesOfValueTypeTest {
             }
 
             @Override
-            public String revert( Object value ) {
-                return valueType().cast( value ).get( 0 );
+            public String revert( List<String> value ) {
+                return value.get( 0 );
             }
 
             @Override

--- a/net.sf.joptsimple/src/main/java/joptsimple/BuiltinHelpFormatter.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/BuiltinHelpFormatter.java
@@ -554,7 +554,7 @@ public class BuiltinHelpFormatter implements HelpFormatter {
         List<String> stringifiedDefaults =
             defaultValues.stream()
                 .map( v -> descriptor.argumentConverter()
-                    .map( c -> c.revert( v ) )
+                    .map( c -> revert( c, v ) )
                     .orElse( String.valueOf( v ) ) )
                 .collect( toList() );
         String defaultValuesDisplay = createDefaultValuesDisplay( stringifiedDefaults );
@@ -562,6 +562,11 @@ public class BuiltinHelpFormatter implements HelpFormatter {
             + ' '
             + surround( message( "default.value.header" ) + ' ' + defaultValuesDisplay, '(', ')' )
         ).trim();
+    }
+
+    // This method is separate in order to capture the generic type <T>
+    private <T> String revert(ValueConverter<T> c, Object v) {
+        return c.revert( c.valueType().cast( v ) );
     }
 
     /**

--- a/net.sf.joptsimple/src/main/java/joptsimple/ValueConverter.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/ValueConverter.java
@@ -50,7 +50,7 @@ public interface ValueConverter<V> {
      * @param value a value
      * @return a string representation of the value
      */
-    default String revert( Object value ) {
+    default String revert( V value ) {
         return String.valueOf( value );
     }
 

--- a/net.sf.joptsimple/src/main/java/joptsimple/util/DateConverter.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/util/DateConverter.java
@@ -84,8 +84,8 @@ public class DateConverter implements ValueConverter<Date> {
     }
 
     @Override
-    public String revert( Object value ) {
-        return formatter.format( valueType().cast( value ) );
+    public String revert( Date value ) {
+        return formatter.format( value );
     }
 
     @Override

--- a/net.sf.joptsimple/src/main/java/joptsimple/util/EnumConverter.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/util/EnumConverter.java
@@ -64,8 +64,8 @@ public abstract class EnumConverter<E extends Enum<E>> implements ValueConverter
     }
 
     @Override
-    public String revert( Object value ) {
-        return valueType().cast( value ).name();
+    public String revert( E value ) {
+        return value.name();
     }
 
     @Override

--- a/net.sf.joptsimple/src/main/java/joptsimple/util/InetAddressConverter.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/util/InetAddressConverter.java
@@ -50,8 +50,8 @@ public class InetAddressConverter implements ValueConverter<InetAddress> {
     }
 
     @Override
-    public String revert( Object value ) {
-        return valueType().cast( value ).getHostName();
+    public String revert( InetAddress value ) {
+        return value.getHostName();
     }
 
     @Override


### PR DESCRIPTION
The method `ValueConverter.revert()` should take a parameter of type `V` rather than `Object`. A `ValueConverter` itself shouldn't be concerned with coercion to type `V`, that's the caller's job.

As it is now, the `Object` parameter makes it harder to create a `ValueConverter` implementation. What is it supposed to do if the `Object` does not have type `V`? The caller is more suited to answering that question - or more likely, ensuring that it never comes up.