### PR TITLE
Allow customizing `enum -> string` logic in EnumConverter

### DIFF
--- a/src/main/java/net/sf/joptsimple/converter/EnumConverter.java
+++ b/src/main/java/net/sf/joptsimple/converter/EnumConverter.java
@@ -102,7 +102,7 @@ public final class EnumConverter<E extends Enum<E>> implements ValueConverter<E>
         StringBuilder builder = new StringBuilder();
         builder.append( delimiters.charAt( 0 ) );
         for ( Iterator<E> i = values.iterator(); i.hasNext(); ) {
-            builder.append( i.next().toString() );
+            builder.append( nameMapper.apply( i.next() ) );
             if ( i.hasNext() )
                 builder.append( delimiters.charAt( 1 ) );
         }

--- a/src/main/java/net/sf/joptsimple/converter/EnumConverter.java
+++ b/src/main/java/net/sf/joptsimple/converter/EnumConverter.java
@@ -29,6 +29,7 @@ import java.text.MessageFormat;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.ResourceBundle;
+import java.util.function.Function;
 
 import net.sf.joptsimple.ValueConversionException;
 import net.sf.joptsimple.ValueConverter;
@@ -42,6 +43,7 @@ public final class EnumConverter<E extends Enum<E>> implements ValueConverter<E>
     private final Class<E> clazz;
 
     private String delimiters = "[,]";
+    private Function<E, String> nameMapper = Enum::name;
 
     private EnumConverter(Class<E> clazz) {
         this.clazz = clazz;
@@ -50,7 +52,7 @@ public final class EnumConverter<E extends Enum<E>> implements ValueConverter<E>
     @Override
     public E convert( String value ) {
         for ( E each : valueType().getEnumConstants() ) {
-            if ( each.name().equalsIgnoreCase( value ) ) {
+            if ( nameMapper.apply( each ).equalsIgnoreCase( value ) ) {
                 return each;
             }
         }
@@ -60,7 +62,7 @@ public final class EnumConverter<E extends Enum<E>> implements ValueConverter<E>
 
     @Override
     public String revert( E value ) {
-        return value.name();
+        return nameMapper.apply( value );
     }
 
     @Override
@@ -77,6 +79,20 @@ public final class EnumConverter<E extends Enum<E>> implements ValueConverter<E>
      */
     public void setDelimiters( String delimiters ) {
         this.delimiters = delimiters;
+    }
+
+    /**
+     * Sets the mapper that maps enum constant to its string representation.
+     * {@code null} resets name mapper to {@link Enum#name() the default mapper}
+     *
+     * @param nameMapper mapper for obtaining an enum's string representation.
+     *                   Default is {@link Enum#name()}
+     */
+    public void setNameMapper( Function<E, String> nameMapper ) {
+        if (nameMapper == null) {
+            nameMapper = Enum::name;
+        }
+        this.nameMapper = nameMapper;
     }
 
     @Override

--- a/src/test/java/net/sf/joptsimple/converter/EnumConverterTest.java
+++ b/src/test/java/net/sf/joptsimple/converter/EnumConverterTest.java
@@ -77,6 +77,36 @@ public class EnumConverterTest {
         assertEquals( TestEnum.A, converter.convert( "a" ) );
     }
 
+    @Test
+    public void customNameMapper() {
+        converter.setNameMapper( e -> switch (e) {
+            case A -> "Alpha";
+            case B -> "Beta";
+            case C -> "Gamma";
+            case D -> "Delta";
+        } );
+
+        assertEquals( TestEnum.A, converter.convert( "Alpha" ) );
+        assertEquals( TestEnum.B, converter.convert( "Beta" ) );
+
+        assertEquals( "Gamma", converter.revert( TestEnum.C ) );
+
+        assertEquals( "[Alpha,Beta,Gamma,Delta]", converter.valuePattern() );
+    }
+
+    @Test
+    public void restoreNameMapper() {
+        // override once to ensure default logic is from reset instead of no-op
+        converter.setNameMapper( e -> e.name().toLowerCase() );
+        converter.setNameMapper(null);
+
+        assertEquals( TestEnum.A, converter.convert( "A") );
+
+        assertEquals( "A", converter.revert( TestEnum.A) );
+
+        assertEquals( "[A,B,C,D]", converter.valuePattern() );
+    }
+
     private static enum TestEnum {
         A, B, C, D
     }


### PR DESCRIPTION
This PR added `nameMapper` field to `EnumConverter` that handles the coversion from enum to its string representation. It defaults to `Enum::name`, and can be customized via `.setNameMapper(...)`. `null` input is allowed, and will reset the mapper back to `Enum::name`.

The `.convert(...)`, `.revert(...)`, and `.valuePattern(...)` now uses the new mapper to convert enum to string. This also fixes a potential behaviour mismatch, where `.valuePattern(...)` calling `Enum#toString()` instead of `Enum#name()` might cause the pattern to be different from actual accepted values.